### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -144,12 +144,13 @@ const LinkList = styled(List)`
   flex: 1;
 `;
 
-const CollapseMenuItem = styled(MenuItemButton)`
+const CollapseMenuItem = styled(MenuItemButton)<{ isCollapsed: boolean }>`
   display: none;
 
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
   }
+  transform: ${({ isCollapsed }) => (isCollapsed ? "rotate(180deg)" : "")};
 `;
 
 export function SidebarNavigation() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "prolog-app",
       "version": "14.5.1",
       "dependencies": {
         "@fontsource/inter": "^4.5.7",


### PR DESCRIPTION
Fix issue, where arrow wasn't changing direction after collapsing menu.